### PR TITLE
explicit provider prefix for gemini model

### DIFF
--- a/lightspeed-stack/run.yaml
+++ b/lightspeed-stack/run.yaml
@@ -27,7 +27,7 @@ providers:
       provider_type: remote::openai
       config:
         api_key: ${env.OPENAI_API_KEY}
-    - provider_id: my-gemini
+    - provider_id: gemini
       provider_type: remote::gemini
       config:
         api_key: ${env.GOOGLE_API_KEY}
@@ -72,5 +72,5 @@ models:
     provider_id: openai
     model_type: llm
     provider_model_id: gpt-4o
-  - model_id: gemini-2.5-flash
-    provider_id: my-gemini
+  - model_id: gemini/gemini-2.5-flash
+    provider_id: gemini


### PR DESCRIPTION
Without `gemini/` prefix, the llamastack had tendency to pick vertex_ai when enabled.